### PR TITLE
Prices moved from beancount.ops to beancount.core

### DIFF
--- a/beancount_plugins_xentac/plugins/unrealized_periodic.py
+++ b/beancount_plugins_xentac/plugins/unrealized_periodic.py
@@ -23,7 +23,7 @@ from beancount.core import getters
 from beancount.core import amount
 from beancount.core import flags
 from beancount.ops import holdings
-from beancount.ops import prices
+from beancount.core import prices
 from beancount.ops import summarize
 from beancount.parser import options
 from beancount.utils import date_utils


### PR DESCRIPTION
prices.py moved from ops to beancount.core in https://bitbucket.org/blais/beancount/commits/f242e083610adffd409007cfa058506e32f19f26